### PR TITLE
Fix collection issue in Redmine 2.6

### DIFF
--- a/app/models/stuff_to_do.rb
+++ b/app/models/stuff_to_do.rb
@@ -191,7 +191,7 @@ class StuffToDo < ActiveRecord::Base
   end
 
   def self.reorder_items(type, user, ids)
-    list = self.all.where(user_id: user.id, stuff_type: type)
+    list = self.where(user_id: user.id, stuff_type: type)
     stuff_to_dos_found = list.collect { |std| std.stuff_id.to_i }
 
     remove_missing_records(user, stuff_to_dos_found, ids.values)


### PR DESCRIPTION
In Redmine 2.6, `Model.all` returns an array, not a collection of objects. This removes the `.all` so you can call `.where` directly to obtain the collection.

---

```
undefined method `where' for []:Array
```
